### PR TITLE
nvdu_viz: Fix display for images > 1280x720

### DIFF
--- a/nvdu/core/nvdu_data.py
+++ b/nvdu/core/nvdu_data.py
@@ -238,12 +238,13 @@ class ExportedObjectSettings(object):
 
 class ExporterSettings(object):
     def __init__(self):
-        self.captured_image_size = [1280, 720]
+        self.captured_image_size = [0, 0]
 
     @classmethod
     def parse_from_json_data(cls, json_data):
         parsed_exporter_settings = ExporterSettings()
-        parsed_exporter_settings.captured_image_size = json_data['captured_image_size']
+        parsed_exporter_settings.captured_image_size = [json_data['camera_settings'][0]['captured_image_size']['width'],
+                                                        json_data['camera_settings'][0]['captured_image_size']['height']]
         print("parsed_exporter_settings.captured_image_size: {}".format(parsed_exporter_settings.captured_image_size))
         
         return parsed_exporter_settings

--- a/nvdu/tools/test_nvdu_visualizer.py
+++ b/nvdu/tools/test_nvdu_visualizer.py
@@ -42,6 +42,7 @@ def main():
     parser = argparse.ArgumentParser(description='NVDU Data Visualiser')
     parser.add_argument('dataset_dir', type=str, nargs='?',
         help="Dataset directory. This is where all the images (required) and annotation info (optional) are. Default is the current directory", default=DEFAULT_data_dir_path)
+    parser.add_argument('-m', '--model_dir', type=str, help="Model directory. Default is <path to nvdu module>/data/ycb/original/", default=get_ycb_root_dir(YCBModelType.Original))
     parser.add_argument('-a', '--data_annot_dir', type=str, help="Directory path - where to find the annotation data. Default is the same directory as the dataset directory", default="")
     parser.add_argument('-s', '--size', type=int, nargs=2, metavar=('WIDTH', 'HEIGHT'), help="Window's size: [width, height]. If not specified then the window fit the resolution of the camera", default=[DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT])
     parser.add_argument('-o', '--object_settings_path', type=str, help="Object settings file path")
@@ -77,8 +78,7 @@ def main():
     # print("Number of frames in the dataset: {}".format(frame_count))
 
     # NOTE: Just use the YCB models path for now
-    # model_dir_path = args.model_dir
-    model_dir_path = get_ycb_root_dir(YCBModelType.Original)
+    model_dir_path = args.model_dir
 
     object_settings_path = args.object_settings_path
     camera_settings_path = args.camera_settings_path

--- a/nvdu/tools/test_nvdu_visualizer.py
+++ b/nvdu/tools/test_nvdu_visualizer.py
@@ -91,6 +91,10 @@ def main():
     dataset_settings = DatasetSettings.parse_from_file(object_settings_path, model_dir_path)
     if (dataset_settings is None):
         print("Error: Could not locate dataset settings at {}".format(object_settings_path))
+    else:
+        if path.exists(camera_settings_path):
+            camera_json_data = json.load(open(camera_settings_path))
+            dataset_settings.exporter_settings = ExporterSettings.parse_from_json_data(camera_json_data)
 
     camera_intrinsic_settings = CameraIntrinsicSettings.from_json_file(camera_settings_path)
     if (camera_intrinsic_settings is None):

--- a/nvdu/viz/background_image.py
+++ b/nvdu/viz/background_image.py
@@ -19,8 +19,8 @@ class BackgroundImage(object):
 
     @classmethod
     def create_from_numpy_image_data(cls, numpy_image_data, width = 0, height = 0):
-        img_width = numpy_image_data.shape[0] if (width == 0) else width
-        img_height = numpy_image_data.shape[1] if (height == 0) else height
+        img_width = numpy_image_data.shape[1] if (width == 0) else width
+        img_height = numpy_image_data.shape[0] if (height == 0) else height
         
         new_image = cls(img_width, img_height)
         new_image.load_image_data_from_numpy(numpy_image_data)


### PR DESCRIPTION
Without this commit, images larger than 1280x720 were cropped. This commit reads the actual image size from the _camera_settings.json file.

Actually, the following change by itself would be enough:

```diff
-        self.captured_image_size = [1280, 720]
+        self.captured_image_size = [0, 0]
```

This causes the image to be displayed at its actual resolution (instead of reading the _camera_settings.json file).